### PR TITLE
Fixed: tailwind config for jsx files

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,8 +1,8 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: ["./src/**/*.{html,js}"],
+  content: ["./src/**/*.{js,jsx,ts,tsx}"],
   theme: {
     extend: {},
   },
   plugins: [],
-}
+};


### PR DESCRIPTION
Earlier tailwind styles wasn't working with jsx files. Fixed it by adding .jsx extension in tailwind config file.